### PR TITLE
feat(40) : Rangoon Logic

### DIFF
--- a/ACT-Project_DX11/Client/Client.cpp
+++ b/ACT-Project_DX11/Client/Client.cpp
@@ -268,9 +268,9 @@ void Client::Init()
 			enemyModel->ReadModel(L"Enemy/Rangoon");
 			enemyModel->ReadMaterial(L"Enemy/Rangoon");
 
-			enemyModel->ReadAnimation(L"Enemy/Rangoon_run", AnimationState::Run);
 			enemyModel->ReadAnimation(L"Enemy/Rangoon_idle", AnimationState::Idle);
-			enemyModel->ReadAnimation(L"Enemy/Rangoon_aggro", AnimationState::Hit);
+			enemyModel->ReadAnimation(L"Enemy/Rangoon_run", AnimationState::Run);
+			enemyModel->ReadAnimation(L"Enemy/Rangoon_aggro", AnimationState::Aggro);
 			enemyModel->ReadAnimation(L"Enemy/Rangoon_atkBigSnippy", AnimationState::Attack1);
 			enemyModel->ReadAnimation(L"Enemy/Rangoon_atkSmallSnippy", AnimationState::Attack2);
 			enemyModel->ReadAnimation(L"Enemy/Rangoon_atkSmash", AnimationState::Attack3);

--- a/ACT-Project_DX11/Client/RangoonScript.h
+++ b/ACT-Project_DX11/Client/RangoonScript.h
@@ -4,7 +4,6 @@
 #include "A_Star.h"
 #include "Model.h"
 #include "ModelAnimator.h"
-#include "PlayerScript.h"
 
 class Model;
 class ModelAnimator;
@@ -20,23 +19,39 @@ public:
 	void SetEnemy(shared_ptr<Model> enemy) { _rangoon = enemy; }
 	shared_ptr<ModelAnimator> GetModelAnimator() { return _modelAnimator; }
 	void SetModelAnimator(shared_ptr<ModelAnimator> modelAnimator) { _modelAnimator = modelAnimator; }
-	void SetAnimationState(AnimationState state); 
+	void SetAnimationState(AnimationState state);
 
-	void Aggro(Vec3& s, Vec3& t);
+	void Aggro();
 	void Move(const Vec3 targetPos);
 	void Rota(const Vec3 targetPos);
-	void Attack();
+	void Attack(int type);
 	void Tracking(Vec3 pos, const std::vector<Node3D>& path);
+	void SetNextType(int type);
 
 	//float angle; 
 	float distance;
 	Vec3 direction;
 	Vec3 CurForward;
-	bool onTarget = false;
+	int atkType = 0;
+	bool _isAnimating = false;
 
 private:
 	float _speed = 0.1f;
 	float _deltaTime = 1.f;
+	float _hp = 100.0f;
+	float _atk = 30.0f;
+	bool onTarget = false;
+	bool onRange = true;
+	bool BackToStart = false;
+	Vec3 StartPos;
+	float rangeDis;
+	bool isAnimating;
+	bool onAttack = false;
+	float _FPS;
+	float _attackDuration[3];
+	float _aggroDuration;
+	bool previousOnTarget = false;
+
 	shared_ptr<Model> _rangoon;
 	shared_ptr<ModelAnimator> _modelAnimator;
 	shared_ptr<Transform> _transform;

--- a/ACT-Project_DX11/Client/RangoonScript.h
+++ b/ACT-Project_DX11/Client/RangoonScript.h
@@ -26,16 +26,7 @@ public:
 	void Rota(const Vec3 targetPos);
 	void Attack(int type);
 	void Tracking(Vec3 pos, const std::vector<Node3D>& path);
-	void SetNextType(int type);
 	void ResetToIdleState();
-
-	void UpdateTimers();
-	void UpdatePlayerInfo();
-	void CheckRanges();
-	void HandleAnimationState();
-	void HandleBackToStart();
-	void HandleChasePlayer();
-	void HandleAttack();
 
 	//float angle; 
 	float distance;
@@ -58,7 +49,7 @@ private:
 	bool onAttack = false;
 	float _attackDuration[3];
 	float _aggroDuration;
-	bool isAggro = false;
+	bool isFirstAggro = false;
 	float animPlayingTime = 0.0f;
 
 	shared_ptr<Model> _rangoon;

--- a/ACT-Project_DX11/Client/RangoonScript.h
+++ b/ACT-Project_DX11/Client/RangoonScript.h
@@ -27,12 +27,21 @@ public:
 	void Attack(int type);
 	void Tracking(Vec3 pos, const std::vector<Node3D>& path);
 	void SetNextType(int type);
+	void ResetToIdleState();
+
+	void UpdateTimers();
+	void UpdatePlayerInfo();
+	void CheckRanges();
+	void HandleAnimationState();
+	void HandleBackToStart();
+	void HandleChasePlayer();
+	void HandleAttack();
 
 	//float angle; 
 	float distance;
 	Vec3 direction;
 	Vec3 CurForward;
-	int atkType = 0;
+	int atkType = 1;
 	bool _isAnimating = false;
 
 private:
@@ -43,14 +52,14 @@ private:
 	bool onTarget = false;
 	bool onRange = true;
 	bool BackToStart = false;
+	float _FPS;
 	Vec3 StartPos;
 	float rangeDis;
-	bool isAnimating;
 	bool onAttack = false;
-	float _FPS;
 	float _attackDuration[3];
 	float _aggroDuration;
-	bool previousOnTarget = false;
+	bool isAggro = false;
+	float animPlayingTime = 0.0f;
 
 	shared_ptr<Model> _rangoon;
 	shared_ptr<ModelAnimator> _modelAnimator;

--- a/ACT-Project_DX11/Client/RangoonScript.h
+++ b/ACT-Project_DX11/Client/RangoonScript.h
@@ -49,7 +49,7 @@ private:
 	bool onAttack = false;
 	float _attackDuration[3];
 	float _aggroDuration;
-	bool isFirstAggro = false;
+	bool isFirstAggro = true;
 	float animPlayingTime = 0.0f;
 
 	shared_ptr<Model> _rangoon;

--- a/ACT-Project_DX11/Client/imgui.ini
+++ b/ACT-Project_DX11/Client/imgui.ini
@@ -1,5 +1,5 @@
 [Window][Debug##Default]
-Pos=564,40
+Pos=567,42
 Size=246,168
 Collapsed=0
 

--- a/ACT-Project_DX11/Engine/Model.cpp
+++ b/ACT-Project_DX11/Engine/Model.cpp
@@ -355,6 +355,7 @@ string Model::AnimationStateToString(AnimationState state)
 	case AnimationState::Hit:   return "Hit";
 	case AnimationState::Die:   return "Die";
 	case AnimationState::Roar:   return "Roar";
+	case AnimationState::Aggro:   return "Aggro";
 		// 다른 상태 추가 가능
 	default: return "Unknown";
 	}

--- a/ACT-Project_DX11/Engine/Types.h
+++ b/ACT-Project_DX11/Engine/Types.h
@@ -37,5 +37,6 @@ enum class AnimationState
 	Hit, //피격
 	Die, //죽음
 	Roar, //울음,포효
+	Aggro,
 	// 다른 상태 추가 가능
 };


### PR DESCRIPTION
## 🔎 작업 내용
- 기본 몬스터 Rangoon 의 로직 구현
- 처음 탐지 범위 내로 들어오면 Aggro 상태
- Aggro가 끝난 후 onTarget(거리 15이하) 이면 Chase 상태
- 거리가 5이하로 줄어 들면 onAttack으로 Attack상태
- 처음 스폰이 된 위치에서 멀어지면 BackToStart 상태로 초기 상태로 돌아감
  <br/>


<br/>
## 🔧 앞으로의 과제
- 모션 및 로직이 부자연스러운 부분이 있어서 그 부분 개선
- 플레이어와 상호 작용
- 
 <br/>

## ➕ 이슈 링크

- [Ragoon Logic #40 

<br/>
